### PR TITLE
Fix check for function .zinit-setup-plugin-dir

### DIFF
--- a/za-readurl-preinit-handler
+++ b/za-readurl-preinit-handler
@@ -40,7 +40,7 @@ za-readurl-preinit-handler() {
   local -a match mbegin mend
   local MATCH
   integer MBEGIN MEND
-  (($ + functions[.zinit - setup - plugin - dir])) || builtin source $ZINIT[BIN_DIR]/zinit-install.zsh
+  (($ + functions[.zinit-setup-plugin-dir])) || builtin source $ZINIT[BIN_DIR]/zinit-install.zsh
   match=()
   local dlpage=${__url%(#b)([^+])++*}
   dlpage=$dlpage$match[1]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Typo was made to this line, so the function contains spaces around the dashes. The script now cannot source `zinit-install.zsh`.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh

```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

Manual

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
