### PR TITLE
Fixed inclusion of zinit-install.sh

### DIFF
--- a/za-readurl-preinit-handler
+++ b/za-readurl-preinit-handler
@@ -40,7 +40,7 @@ za-readurl-preinit-handler() {
   local -a match mbegin mend
   local MATCH
   integer MBEGIN MEND
-  (( ${+functions[.zinit-setup-plugin-dir]} != 1 )) || builtin source $ZINIT[BIN_DIR]/zinit-install.zsh
+  (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source $ZINIT[BIN_DIR]/zinit-install.zsh
   match=()
   local dlpage=${__url%(#b)([^+])++*}
   dlpage=$dlpage$match[1]


### PR DESCRIPTION


## Description

functions[.zinit-setup-plugin-dir] != 1 is inverted and throughout zinit code this constract is used without != 1

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh

```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
